### PR TITLE
Initaillize CardList component

### DIFF
--- a/src/components/UI/CardList.tsx
+++ b/src/components/UI/CardList.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+import CardSection, { CardSectionProps } from "./CardSection";
+
+export interface CardListProps {
+    cards: CardSectionProps[];
+}
+
+export const CardList = ({ cards }: CardListProps) => {
+    return (
+        <div className="flex p-4 space-x-4 overflow-x-auto">
+            {cards.map((card, index) => (
+                <div key={index} className="flex-shrink-0">
+                    <CardSection title={card.title} illustration={card.illustration} />
+                </div>
+            ))}
+        </div>
+    )
+}


### PR DESCRIPTION
cardlist 컴포넌트는 cardsection 컴포넌트를 가로로 나열하는 역할을 하는 컴포넌트
cardsectionprops는 card를 배열로 받아 렌더링 하며, flex와 overflow-x-auto를 활용해 가로 스크롤이 가능하도록 설계
flex-shrink-0를 통해 카드가 크기를 유지하도록 처리, 카드 간 간격은 추후 조정