### PR TITLE
feat: memory page fin section

### DIFF
--- a/src/pages/memory.tsx
+++ b/src/pages/memory.tsx
@@ -6,6 +6,7 @@ import { emotionSmallImageMap } from '@/utils/emotionSmallMap';
 import Image from 'next/image';
 import React, { useState } from 'react';
 import { useSTT } from '@/utils/useSTT'
+import Button from '@/components/UI/Button';
 
 const MemoryPage = () => {
     const { transcript, listening, resetTranscript } = useSTT("ko-KR");  //STT 훅을 사용하여 음성 인식 결과와 상태를 가져옴
@@ -64,6 +65,16 @@ const MemoryPage = () => {
             icon: 'camera.svg',
             iconSize: 228,
             micMessage: '마이크를 눌러 말해보세요',
+        },
+        {
+            id: 4,
+            title: <h2 className='w-full text-xl font-semibold leading-6 tracking-tight text-center text-white'>
+                    오늘 하루가<br />추억되었어요!
+                </h2>,
+            emotion: 'nothing',
+            icon: 'flower.svg',
+            iconSize: 228,
+            micMessage: undefined,
         }
     ]
 
@@ -124,6 +135,11 @@ const MemoryPage = () => {
                                     <p className={`text-center text-sm text-white`}>{value.text}</p>
                                     </div>
                                 ))}
+                        </div>
+                    ) : recordStatus === 4 ? (
+                        <div className='flex flex-col w-full h-auto gap-4 px-6'>
+                            <Button text='기억퀴즈 풀기' onClick={() => {}} className='rounded-[1.25rem] w-full py-4 text-lg font-semibold text-center leading-[1.4375rem] tracking tight bg-primary text-black'></Button>
+                            <Button text='홈으로 나가기' onClick={() => {}} className='rounded-[1.25rem] w-full py-4 text-lg font-semibold text-center leading-[1.4375rem] tracking tight bg-gray3 text-gray2'></Button>
                         </div>
                     ) : (
                             <SpeechInput onClick={handleRecord} />


### PR DESCRIPTION
## 📌 개요

> 이번 PR에서 어떤 작업을 했는지 간단히 설명해주세요.  
> 예: 로그인 화면 UI 개선, 회원가입 API 연동 등
추억하기 페이지에서 마무리 부분을 구현함

---

## 🧩 주요 변경사항

- 작업한 파일/컴포넌트:memory.tsx
- 주요 변경 사항 요약: 5번째 section을 구현

---

## ⚙️ 구현 방식

---

## 📸 스크린샷 (UI 변경 시 필수)
> UI 변경이 있다면 Before/After 이미지 또는 GIF 첨부
<img width="445" height="745" alt="image" src="https://github.com/user-attachments/assets/685589f9-01de-40c5-b814-d35cb53829f0" />

---

## 🛠️ 향후 개선점
- icon 변경
- onclick props 에 페이지 연결
- 좌우 버튼 disabled & 안보이게 처리

---

## 🙋 기타 참고 사항
> 리뷰어에게 전달하고 싶은 말이나 주의할 점이 있다면 작성해주세요.
