### PR TITLE
faet: 화면에 푸터 추가 및 클릭 시 이동이 필요한 부분 라우터 추가 + 스플래시 화면 추가

### DIFF
--- a/src/pages/badge.tsx
+++ b/src/pages/badge.tsx
@@ -4,6 +4,7 @@ import CircleGraph from "@/components/UI/CircleGraph";
 import BadgeCard from "@/components/UI/BadgeCard";
 import BadgePopup from "@/components/UI/BadgePopup";
 import AppBackground from "@/components/APP/AppBackground";
+import AppFooter from "@/components/APP/AppFooter";
 
 const badgeGoals = [3, 7, 14, 30];
 
@@ -100,6 +101,7 @@ const BadgePage = () => {
           onClose={() => setShowPopup(false)}
         />
       )}
+      <AppFooter />
     </div>
   );
 };

--- a/src/pages/calendar.tsx
+++ b/src/pages/calendar.tsx
@@ -10,6 +10,7 @@ import { getCalendarWeeks } from "../utils/Date";
 import { getEmotionByDate } from "../utils/emotionUtils";
 import AppBackground from "@/components/APP/AppBackground";
 import { useRouter } from "next/router";
+import AppFooter from "@/components/APP/AppFooter";
 
 const Calendar = () => {
   const mockEmotionMap: Record<string, CalendarCardProps["emotion"]> = {
@@ -121,6 +122,7 @@ const Calendar = () => {
               ))}
             </div>
           </div>
+          <AppFooter />
         </div>
       </AppBackground>
     </div>

--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import AppBackground from "@/components/APP/AppBackground";
+import AppFooter from "@/components/APP/AppFooter";
 
 const days = ["월", "화", "수", "목", "금", "토", "일"];
 const emotions = [
@@ -58,6 +59,7 @@ const HomePage = () => {
               ))}
             </div>
           </div>
+          <AppFooter />
         </div>
       </AppBackground>
     </div>

--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import AppBackground from "@/components/APP/AppBackground";
 import AppFooter from "@/components/APP/AppFooter";
+import { useRouter } from "next/navigation";
 
 const days = ["월", "화", "수", "목", "금", "토", "일"];
 const emotions = [
@@ -14,6 +15,8 @@ const emotions = [
 ];
 
 const HomePage = () => {
+  const router = useRouter();
+
   return (
     <div className="relative h-screen w-full overflow-hidden font-[var(--font-family)] text-white">
       <AppBackground backgroundImage="/images/home_background_img.png">
@@ -27,7 +30,10 @@ const HomePage = () => {
           </div>
 
           <div className="flex justify-center">
-            <button className="w-[230px] h-[230px] bg-primary text-black rounded-full text-[32px] font-semibold shadow-yellow leading-[26px]">
+            <button
+              onClick={() => router.push("/memory")}
+              className="w-[230px] h-[230px] bg-primary text-black rounded-full text-[32px] font-semibold shadow-yellow leading-[26px]"
+            >
               추억하기
             </button>
           </div>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,16 +1,34 @@
-// import Button from "@/components/UI/Button";
-// import SpeechInput from "@/components/UI/SpeechInput";
-// import { useTTS } from "@/utils/useTTS";
+"use client";
+import { useEffect } from "react";
+import { useRouter } from "next/router";
+import AppBackground from "@/components/APP/AppBackground";
+import Image from "next/image";
 
 const Main = () => {
-  // const { speak } = useTTS();
+  const router = useRouter();
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      router.push("/login");
+    }, 2000); // 2초 후 이동
+
+    return () => clearTimeout(timer);
+  }, [router]);
 
   return (
-    <div>
-      <p>indexpage</p>
-      {/* <Button text="hi" className="p-2 rounded text-background bg-primary" />
-      <SpeechInput />
-      <p onClick={() => {speak('가나다라')}}>가나다라마바사아자카타파하</p> */}
+    <div className="h-screen">
+      <AppBackground backgroundImage="/images/home_background_img.png">
+        <div className="flex flex-col items-center justify-center h-full">
+          <Image
+            src="/thinkeep_symbol.svg"
+            alt="symbol"
+            width={160}
+            height={120}
+            className="mb-4"
+          />
+          <Image src="/thinkeep_logo.svg" alt="logo" width={160} height={50} />
+        </div>
+      </AppBackground>
     </div>
   );
 };

--- a/src/pages/memory.tsx
+++ b/src/pages/memory.tsx
@@ -1,153 +1,210 @@
-import BarGraph from '@/components/UI/BarGraph';
-import { HeaderBackward } from '@/components/UI/HeaderBacward';
-import QuestionCard from '@/components/UI/QuestionCard';
-import SpeechInput from '@/components/UI/SpeechInput';
-import { emotionSmallImageMap } from '@/utils/emotionSmallMap';
-import Image from 'next/image';
-import React, { useState } from 'react';
-import { useSTT } from '@/hooks/useSTT'
-import Button from '@/components/UI/Button';
+import BarGraph from "@/components/UI/BarGraph";
+import { HeaderBackward } from "@/components/UI/HeaderBacward";
+import QuestionCard from "@/components/UI/QuestionCard";
+import SpeechInput from "@/components/UI/SpeechInput";
+import { emotionSmallImageMap } from "@/utils/emotionSmallMap";
+import Image from "next/image";
+import React, { useState } from "react";
+import { useSTT } from "@/hooks/useSTT";
+import Button from "@/components/UI/Button";
+import { useRouter } from "next/navigation";
 
 const MemoryPage = () => {
-    const { transcript, listening, resetTranscript } = useSTT("ko-KR");  //STT 훅을 사용하여 음성 인식 결과와 상태를 가져옴
+  const router = useRouter();
+  const { transcript, listening, resetTranscript } = useSTT("ko-KR"); //STT 훅을 사용하여 음성 인식 결과와 상태를 가져옴
 
-    const [recordStatus, setRecordStatus] = useState(0);    //0~3 으로 나타낼 cardsection을 기록
-    const handleRecordStatusChange = (newStatus: number) => {
-        setRecordStatus(newStatus);
-        resetTranscript();
-    };
+  const [recordStatus, setRecordStatus] = useState(0); //0~3 으로 나타낼 cardsection을 기록
+  const handleRecordStatusChange = (newStatus: number) => {
+    setRecordStatus(newStatus);
+    resetTranscript();
+  };
 
-    const [userEmotion, setUserEmotion] = useState('nothing');  //감정을 기록, 초기값은 nothing
-    const handleUserEmotionChange = (newEmotion: string) => {
-        if (newEmotion === userEmotion) {
-            setUserEmotion('nothing');  //이미 선택된 감정을 다시 클릭하면 nothing으로 변경
-        } else {
-            setUserEmotion(newEmotion);
-        }
-    };
-
-    const cardList = [
-        {   
-            id: 0,
-            title: <h2 className='w-full text-xl font-semibold leading-6 tracking-tight text-center text-white'>
-                    오늘 <span className='text-primary'>기분</span>이 어때요?
-                </h2>,
-            emotion: userEmotion,
-            icon: '/emotions/howEmotion.svg',
-            iconSize: 228,
-            micMessage: undefined,
-        },
-        {
-            id: 1,
-            title: <h2 className='w-full text-xl font-semibold leading-6 tracking-tight text-center text-white'>
-                    오늘 <span className='text-primary'>누구</span>와 함께<br />시간을 보냈나요?
-                </h2>,
-            emotion: 'nothing',
-            icon: 'flower.svg',
-            iconSize: 228,
-            micMessage: '마이크를 눌러 말해보세요',
-        },
-        {
-            id: 2,
-            title: <h2 className='w-full text-xl font-semibold leading-6 tracking-tight text-center text-white'>
-                    오늘 먹은 식사 중에서 <span className='text-primary'>가장 기억에<br />남는 음식</span>은 무엇인가요?
-                </h2>,
-            emotion: 'nothing',
-            icon: 'flower.svg',
-            iconSize: 228,
-            micMessage: '마이크를 눌러 말해보세요',
-        }, {
-            id: 3,
-            title: <h2 className='w-full text-xl font-semibold leading-6 tracking-tight text-center text-white'>
-                    오늘 하루 중 <span className='text-primary'>가장 기억에 남는<br />경험</span>은 무엇인가요?
-                </h2>,
-            emotion: 'nothing',
-            icon: 'camera.svg',
-            iconSize: 228,
-            micMessage: '마이크를 눌러 말해보세요',
-        },
-        {
-            id: 4,
-            title: <h2 className='w-full text-xl font-semibold leading-6 tracking-tight text-center text-white'>
-                    오늘 하루가<br />추억되었어요!
-                </h2>,
-            emotion: 'nothing',
-            icon: 'flower.svg',
-            iconSize: 228,
-            micMessage: undefined,
-        }
-    ]
-
-    const currentCard = cardList.find((card) => card.id === recordStatus)   //recordStatus에 해당하는 card를 찾음
-
-    const [response, setResponse] = useState<Record<number, string>>({
-        1: "",
-        2: "",
-        3: "",
-    });     //STT 결과를 저장할 상태
-
-    const handleRecord = () => {
-        if (listening) {
-            setResponse((prev) => ({
-                ...prev,
-                [recordStatus]: transcript,  //현재 상태에 해당하는 STT 결과를 저장
-            }));
-        } 
+  const [userEmotion, setUserEmotion] = useState("nothing"); //감정을 기록, 초기값은 nothing
+  const handleUserEmotionChange = (newEmotion: string) => {
+    if (newEmotion === userEmotion) {
+      setUserEmotion("nothing"); //이미 선택된 감정을 다시 클릭하면 nothing으로 변경
+    } else {
+      setUserEmotion(newEmotion);
     }
+  };
 
-    return (
-        <div className='h-screen bg-background'>
+  const cardList = [
+    {
+      id: 0,
+      title: (
+        <h2 className="w-full text-xl font-semibold leading-6 tracking-tight text-center text-white">
+          오늘 <span className="text-primary">기분</span>이 어때요?
+        </h2>
+      ),
+      emotion: userEmotion,
+      icon: "/emotions/howEmotion.svg",
+      iconSize: 228,
+      micMessage: undefined,
+    },
+    {
+      id: 1,
+      title: (
+        <h2 className="w-full text-xl font-semibold leading-6 tracking-tight text-center text-white">
+          오늘 <span className="text-primary">누구</span>와 함께
+          <br />
+          시간을 보냈나요?
+        </h2>
+      ),
+      emotion: "nothing",
+      icon: "flower.svg",
+      iconSize: 228,
+      micMessage: "마이크를 눌러 말해보세요",
+    },
+    {
+      id: 2,
+      title: (
+        <h2 className="w-full text-xl font-semibold leading-6 tracking-tight text-center text-white">
+          오늘 먹은 식사 중에서{" "}
+          <span className="text-primary">
+            가장 기억에
+            <br />
+            남는 음식
+          </span>
+          은 무엇인가요?
+        </h2>
+      ),
+      emotion: "nothing",
+      icon: "flower.svg",
+      iconSize: 228,
+      micMessage: "마이크를 눌러 말해보세요",
+    },
+    {
+      id: 3,
+      title: (
+        <h2 className="w-full text-xl font-semibold leading-6 tracking-tight text-center text-white">
+          오늘 하루 중{" "}
+          <span className="text-primary">
+            가장 기억에 남는
+            <br />
+            경험
+          </span>
+          은 무엇인가요?
+        </h2>
+      ),
+      emotion: "nothing",
+      icon: "camera.svg",
+      iconSize: 228,
+      micMessage: "마이크를 눌러 말해보세요",
+    },
+    {
+      id: 4,
+      title: (
+        <h2 className="w-full text-xl font-semibold leading-6 tracking-tight text-center text-white">
+          오늘 하루가
+          <br />
+          추억되었어요!
+        </h2>
+      ),
+      emotion: "nothing",
+      icon: "flower.svg",
+      iconSize: 228,
+      micMessage: undefined,
+    },
+  ];
 
-            <div className='flex flex-row gap-4 p-4'>   {/*header*/}
-                <HeaderBackward visible={true} />
-                <BarGraph total={4} recorded={recordStatus} />
-            </div>
-            <div className='flex flex-col items-center w-full h-full gap-12 pt-4'>
-                <div className='flex flex-row justify-around w-full px-4'>    {/*body*/}
-                    <button className='py-2 text-black rounded bg-primary ' onClick={() => handleRecordStatusChange(recordStatus - 1)}>-1</button>
-                    {currentCard && (
-                        <QuestionCard
-                            title={currentCard.title}
-                            emotion={currentCard.emotion}
-                            iconSize={currentCard.iconSize}
-                            icon={currentCard.icon}
-                            micMessage={currentCard.micMessage}
-                            externalValue={response[recordStatus]}  // 현재 상태에 해당하는 STT 결과를 전달
-                        />
-                    )}
-                    <button className='py-2 text-black rounded bg-primary ' onClick={() => handleRecordStatusChange(recordStatus + 1)}>+1</button>
-                </div>
-                <div className='flex flex-col items-center w-full'>   {/*footer*/}
-                    {recordStatus === 0 ? (
-                        <div className='grid w-full grid-cols-3'>
-                            {Object.entries(emotionSmallImageMap)
-                                .filter(([key]) => key !== "disabled")
-                                .map(([key, value]) => (
-                                    <div key={key} className='flex flex-col items-center justify-center w-full p-2'>
-                                        <Image
-                                            src={userEmotion === key ? value.image : value.monochrome}
-                                        alt={key}
-                                        width={87}
-                                        height={87}
-                                        className=''
-                                        onClick={() => handleUserEmotionChange(key)}
-                                    />
-                                    <p className={`text-center text-sm text-white`}>{value.text}</p>
-                                    </div>
-                                ))}
-                        </div>
-                    ) : recordStatus === 4 ? (
-                        <div className='flex flex-col w-full h-auto gap-4 px-6'>
-                            <Button text='기억퀴즈 풀기' onClick={() => {}} className='rounded-[1.25rem] w-full py-4 text-lg font-semibold text-center leading-[1.4375rem] tracking tight bg-primary text-black'></Button>
-                            <Button text='홈으로 나가기' onClick={() => {}} className='rounded-[1.25rem] w-full py-4 text-lg font-semibold text-center leading-[1.4375rem] tracking tight bg-gray3 text-gray2'></Button>
-                        </div>
-                    ) : (
-                            <SpeechInput onClick={handleRecord} />
-                    )}
-                </div>
-            </div>
+  const currentCard = cardList.find((card) => card.id === recordStatus); //recordStatus에 해당하는 card를 찾음
+
+  const [response, setResponse] = useState<Record<number, string>>({
+    1: "",
+    2: "",
+    3: "",
+  }); //STT 결과를 저장할 상태
+
+  const handleRecord = () => {
+    if (listening) {
+      setResponse((prev) => ({
+        ...prev,
+        [recordStatus]: transcript, //현재 상태에 해당하는 STT 결과를 저장
+      }));
+    }
+  };
+
+  return (
+    <div className="h-screen bg-background">
+      <div className="flex flex-row gap-4 p-4">
+        {" "}
+        {/*header*/}
+        <HeaderBackward visible={true} />
+        <BarGraph total={4} recorded={recordStatus} />
+      </div>
+      <div className="flex flex-col items-center w-full h-full gap-12 pt-4">
+        <div className="flex flex-row justify-around w-full px-4">
+          {" "}
+          {/*body*/}
+          <button
+            className="py-2 text-black rounded bg-primary "
+            onClick={() => handleRecordStatusChange(recordStatus - 1)}
+          >
+            -1
+          </button>
+          {currentCard && (
+            <QuestionCard
+              title={currentCard.title}
+              emotion={currentCard.emotion}
+              iconSize={currentCard.iconSize}
+              icon={currentCard.icon}
+              micMessage={currentCard.micMessage}
+              externalValue={response[recordStatus]} // 현재 상태에 해당하는 STT 결과를 전달
+            />
+          )}
+          <button
+            className="py-2 text-black rounded bg-primary "
+            onClick={() => handleRecordStatusChange(recordStatus + 1)}
+          >
+            +1
+          </button>
         </div>
-    )
+        <div className="flex flex-col items-center w-full">
+          {" "}
+          {/*footer*/}
+          {recordStatus === 0 ? (
+            <div className="grid w-full grid-cols-3">
+              {Object.entries(emotionSmallImageMap)
+                .filter(([key]) => key !== "disabled")
+                .map(([key, value]) => (
+                  <div
+                    key={key}
+                    className="flex flex-col items-center justify-center w-full p-2"
+                  >
+                    <Image
+                      src={userEmotion === key ? value.image : value.monochrome}
+                      alt={key}
+                      width={87}
+                      height={87}
+                      className=""
+                      onClick={() => handleUserEmotionChange(key)}
+                    />
+                    <p className={`text-center text-sm text-white`}>
+                      {value.text}
+                    </p>
+                  </div>
+                ))}
+            </div>
+          ) : recordStatus === 4 ? (
+            <div className="flex flex-col w-full h-auto gap-4 px-6">
+              <Button
+                text="기억퀴즈 풀기"
+                onClick={() => {}}
+                className="rounded-[1.25rem] w-full py-4 text-lg font-semibold text-center leading-[1.4375rem] tracking tight bg-primary text-black"
+              ></Button>
+              <Button
+                text="홈으로 나가기"
+                onClick={() => router.push("/home")}
+                className="rounded-[1.25rem] w-full py-4 text-lg font-semibold text-center leading-[1.4375rem] tracking tight bg-gray3 text-gray2"
+              ></Button>
+            </div>
+          ) : (
+            <SpeechInput onClick={handleRecord} />
+          )}
+        </div>
+      </div>
+    </div>
+  );
 };
 
 export default MemoryPage;

--- a/src/pages/option.tsx
+++ b/src/pages/option.tsx
@@ -4,6 +4,7 @@ import React, { useState } from "react";
 import Image from "next/image";
 import Toggle from "@/components/UI/Toggle";
 import AppBackground from "@/components/APP/AppBackground";
+import AppFooter from "@/components/APP/AppFooter";
 
 const OptionPage = () => {
   const [isTextBig, setIsTextBig] = useState(false);
@@ -73,6 +74,7 @@ const OptionPage = () => {
                 </div>
               </div>
             </div>
+            <AppFooter />
           </div>
         </AppBackground>
       </div>


### PR DESCRIPTION
## 📌 개요

> 이번 PR에서 어떤 작업을 했는지 간단히 설명해주세요.  
> 예: 로그인 화면 UI 개선, 회원가입 API 연동 등

푸터 미추가한 화면에 추가
홈화면에 추억하기 버튼 클릭시 메모리 화면으로 이동
메모리 화면 홈화면 이동 클릭시 홈으로 이동
첫 화면 스플래시 화면으로 설정 2초후 자동 로그인 화면으로 이동됨


